### PR TITLE
test(connectObservable): add test combining ErrorBoundary and Suspense

### DIFF
--- a/test/connectObservable.test.tsx
+++ b/test/connectObservable.test.tsx
@@ -266,7 +266,7 @@ describe("connectObservable", () => {
     )
   })
 
-  it("allows errors to be caught in error boundaries with suspense", () => {
+  it("allows errors to be caught in error boundaries with suspense", async () => {
     const errStream = new Subject()
     const [useError] = connectObservable(errStream)
 
@@ -287,6 +287,10 @@ describe("connectObservable", () => {
 
     componentAct(() => {
       errStream.error("controlled error")
+    })
+
+    await componentAct(async () => {
+      await wait(0)
     })
 
     expect(errorCallback).toHaveBeenCalledWith(

--- a/test/connectObservable.test.tsx
+++ b/test/connectObservable.test.tsx
@@ -266,6 +266,35 @@ describe("connectObservable", () => {
     )
   })
 
+  it("allows errors to be caught in error boundaries with suspense", () => {
+    const errStream = new Subject()
+    const [useError] = connectObservable(errStream)
+
+    const ErrorComponent = () => {
+      const value = useError()
+
+      return <>{value}</>
+    }
+
+    const errorCallback = jest.fn()
+    render(
+      <TestErrorBoundary onError={errorCallback}>
+        <Suspense fallback={<div>Loading...</div>}>
+          <ErrorComponent />
+        </Suspense>
+      </TestErrorBoundary>,
+    )
+
+    componentAct(() => {
+      errStream.error("controlled error")
+    })
+
+    expect(errorCallback).toHaveBeenCalledWith(
+      "controlled error",
+      expect.any(Object),
+    )
+  })
+
   it("doesn't throw errors on components that will get unmounted on the next cycle", () => {
     const valueStream = new BehaviorSubject(1)
     const [useValue, value$] = connectObservable(valueStream)


### PR DESCRIPTION
I've found this issue where if a stream throws an error before emitting any value, the error can't be caught in an ErrorBoundary.

I've made this test that describes the issue and fails with the current version. A codesandbox can be found [here](https://codesandbox.io/s/react-rxjs-playground-dm3tl?file=/src/App.tsx)

For reference, react uses this [sandbox](https://codesandbox.io/s/reactsuspenseerror-b5qu0?file=/src/fakeApi.js) to show how the error is caught also in data fetching. I had a quick look and I think that they have it working because  the component throws an error if the promise rejected.