### PR TITLE
chore(shareLatest): simplify implementation

### DIFF
--- a/packages/core/src/internal/share-latest.ts
+++ b/packages/core/src/internal/share-latest.ts
@@ -52,19 +52,16 @@ const shareLatest = <T>(
       innerSub.unsubscribe()
       if (refCount === 0) {
         currentValue = EMPTY_VALUE
-        if (subject !== undefined) {
-          teardown()
-        } else {
-          setTimeout(teardown, 200)
-        }
-        subject = undefined
         if (subscription) {
           subscription.unsubscribe()
         }
+        teardown()
+        subject = undefined
         subscription = undefined
       }
     }
   }) as BehaviorObservable<T>
+
   result.getValue = () => {
     if (currentValue === EMPTY_VALUE || currentValue === (SUSPENSE as any)) {
       throw currentValue


### PR DESCRIPTION
I noticed this silly (and kinda superfluous) logic on `shareLatest`... It's a mistake that I made when I wrote the code for supporting error boundaries on suspense and I'm quite confident this is the correct code. It's difficult to come up with a breaking test, because AFAIK the previous code didn't trigger any issues.