### PR TITLE
v0.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/re-rxjs/react-rxjs.git"

--- a/packages/core/src/Subscribe.test.tsx
+++ b/packages/core/src/Subscribe.test.tsx
@@ -4,10 +4,8 @@ import { defer, Subject } from "rxjs"
 import { share, finalize } from "rxjs/operators"
 import { Subscribe } from "./"
 
-const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
-
 describe("Subscribe", () => {
-  it("subscribes to the provided observable and remains subscribed until it's unmounted", async () => {
+  it("subscribes to the provided observable and remains subscribed until it's unmounted", () => {
     let nSubscriptions = 0
     const source$ = defer(() => {
       nSubscriptions++
@@ -28,10 +26,6 @@ describe("Subscribe", () => {
     expect(nSubscriptions).toBe(1)
 
     unmount()
-    expect(nSubscriptions).toBe(1)
-
-    await wait(250)
-
     expect(nSubscriptions).toBe(0)
   })
 })

--- a/packages/core/src/Subscribe.tsx
+++ b/packages/core/src/Subscribe.tsx
@@ -7,15 +7,12 @@ import { Observable } from "rxjs"
  * the component mounts and it unsubscribes when the component unmounts.
  *
  * @param source$ Source observable that the Component will subscribe to.
- * @param graceTime (= 200): Amount of time in ms that the Component should wait
- * before unsubscribing from the source observable after it unmounts.
  *
  * @remarks This Component doesn't trigger any updates.
  */
 export const Subscribe: React.FC<{
   source$: Observable<any>
-  graceTime?: number
-}> = ({ source$, graceTime, children }) => {
-  useSubscribe(source$, graceTime)
+}> = ({ source$, children }) => {
+  useSubscribe(source$)
   return <>{children}</>
 }

--- a/packages/core/src/Subscribe.tsx
+++ b/packages/core/src/Subscribe.tsx
@@ -1,5 +1,4 @@
-import React from "react"
-import { useSubscribe } from "./useSubscribe"
+import React, { useState, useEffect } from "react"
 import { Observable } from "rxjs"
 
 /**
@@ -7,12 +6,19 @@ import { Observable } from "rxjs"
  * the component mounts and it unsubscribes when the component unmounts.
  *
  * @param source$ Source observable that the Component will subscribe to.
+ * @param fallback (=null) JSX Element to be rendered before the subscription exists.
  *
  * @remarks This Component doesn't trigger any updates.
  */
 export const Subscribe: React.FC<{
   source$: Observable<any>
-}> = ({ source$, children }) => {
-  useSubscribe(source$)
-  return <>{children}</>
+  fallback?: null | JSX.Element
+}> = ({ source$, children, fallback }) => {
+  const [mounted, setMounted] = useState(0)
+  useEffect(() => {
+    const subscription = source$.subscribe()
+    setMounted(1)
+    return () => subscription.unsubscribe()
+  }, [source$])
+  return <>{mounted ? children : fallback}</>
 }

--- a/packages/core/src/bind/connectFactoryObservable.test.tsx
+++ b/packages/core/src/bind/connectFactoryObservable.test.tsx
@@ -190,9 +190,8 @@ describe("connectFactoryObservable", () => {
         return from([1, 2, 3, 4, 5])
       })
 
-      const [useLatestNumber] = bind(
-        (id: number) => concat(observable$, of(id)),
-        100,
+      const [useLatestNumber] = bind((id: number) =>
+        concat(observable$, of(id)),
       )
       const { unmount } = renderHook(() => useLatestNumber(6))
       const { unmount: unmount2 } = renderHook(() => useLatestNumber(6))
@@ -202,12 +201,13 @@ describe("connectFactoryObservable", () => {
       unmount2()
       unmount3()
 
-      await wait(90)
+      await wait(230)
       const { unmount: unmount4 } = renderHook(() => useLatestNumber(6))
       expect(nInitCount).toBe(1)
-      unmount4()
 
-      await wait(110)
+      unmount4()
+      await wait(270)
+
       renderHook(() => useLatestNumber(6))
       expect(nInitCount).toBe(2)
     })
@@ -394,7 +394,7 @@ describe("connectFactoryObservable", () => {
       const [useLatestNumber, getShared] = bind((_: number) => {
         diff++
         return from([1, 2, 3, 4].map((val) => val + diff))
-      }, 0)
+      })
 
       let latestValue1: number = 0
       let nUpdates = 0
@@ -429,7 +429,7 @@ describe("connectFactoryObservable", () => {
       expect(sub3.closed).toBe(true)
 
       unmount()
-      await wait(10)
+      await wait(260)
 
       let latestValue4: number = 0
       const sub4 = getShared(0).subscribe((x) => {

--- a/packages/core/src/bind/connectFactoryObservable.ts
+++ b/packages/core/src/bind/connectFactoryObservable.ts
@@ -20,9 +20,6 @@ import { takeUntilComplete } from "../internal/take-until-complete"
  *
  * @param getObservable Factory of observables. The arguments of this function
  *  will be the ones used in the hook.
- * @param unsubscribeGraceTime (= 200): Amount of time in ms that the shared
- *  observable should wait before unsubscribing from the source observable when
- *  there are no new subscribers.
  *
  * @remarks If the Observable doesn't synchronously emit a value upon the first
  * subscription, then the hook will leverage React Suspense while it's waiting
@@ -30,7 +27,6 @@ import { takeUntilComplete } from "../internal/take-until-complete"
  */
 export default function connectFactoryObservable<A extends [], O>(
   getObservable: (...args: A) => Observable<O>,
-  unsubscribeGraceTime: number,
 ): [
   (...args: A) => Exclude<O, typeof SUSPENSE>,
   (...args: A) => Observable<O>,
@@ -54,10 +50,7 @@ export default function connectFactoryObservable<A extends [], O>(
       cache.delete(keys)
     })
 
-    const reactObservable$ = reactEnhancer(
-      sharedObservable$,
-      unsubscribeGraceTime,
-    )
+    const reactObservable$ = reactEnhancer(sharedObservable$)
 
     const result: [Observable<O>, BehaviorObservable<O>] = [
       takeUntilComplete(sharedObservable$),

--- a/packages/core/src/bind/connectObservable.test.tsx
+++ b/packages/core/src/bind/connectObservable.test.tsx
@@ -86,7 +86,7 @@ describe("connectObservable", () => {
 
   it("updates more than one component", async () => {
     const value = new Subject<number>()
-    const [useValue] = bind(value.pipe(startWith(0)), 50)
+    const [useValue] = bind(value.pipe(startWith(0)))
     const { result: result1, unmount: unmount1 } = renderHook(() => useValue())
     const { result: result2, unmount: unmount2 } = renderHook(() => useValue())
     const { result: result3, unmount: unmount3 } = renderHook(() => useValue())
@@ -112,7 +112,7 @@ describe("connectObservable", () => {
     unmount4()
 
     await act(async () => {
-      await wait(60)
+      await wait(260)
     })
 
     const { result: result2_1 } = renderHook(() => useValue())
@@ -164,7 +164,7 @@ describe("connectObservable", () => {
       return from([1, 2, 3, 4, 5])
     })
 
-    const [useLatestNumber] = bind(observable$, 100)
+    const [useLatestNumber] = bind(observable$)
     const { unmount } = renderHook(() => useLatestNumber())
     const { unmount: unmount2 } = renderHook(() => useLatestNumber())
     const { unmount: unmount3 } = renderHook(() => useLatestNumber())
@@ -173,37 +173,14 @@ describe("connectObservable", () => {
     unmount2()
     unmount3()
 
-    await wait(85)
+    await wait(230)
     const { unmount: unmount4 } = renderHook(() => useLatestNumber())
     expect(nInitCount).toBe(1)
     unmount4()
 
-    await wait(125)
+    await wait(270)
     renderHook(() => useLatestNumber())
     expect(nInitCount).toBe(2)
-  })
-
-  it("it never closes the last subscription when the grace-period is Infinity", async () => {
-    let nInitCount = 0
-    const observable$ = defer(() => {
-      nInitCount += 1
-      return from([1, 2, 3, 4, 5])
-    })
-
-    const [useLatestNumber] = bind(observable$, Infinity)
-    const { unmount } = renderHook(() => useLatestNumber())
-    const { unmount: unmount2 } = renderHook(() => useLatestNumber())
-    const { unmount: unmount3 } = renderHook(() => useLatestNumber())
-    const { unmount: unmount4 } = renderHook(() => useLatestNumber())
-    expect(nInitCount).toBe(1)
-    unmount()
-    unmount2()
-    unmount3()
-    unmount4()
-
-    await wait(300)
-    renderHook(() => useLatestNumber())
-    expect(nInitCount).toBe(1)
   })
 
   it("suspends the component when the observable emits SUSPENSE", async () => {

--- a/packages/core/src/bind/connectObservable.ts
+++ b/packages/core/src/bind/connectObservable.ts
@@ -14,23 +14,14 @@ import { takeUntilComplete } from "../internal/take-until-complete"
  * there are no subscribers to that observable.
  *
  * @param observable Source observable to be used by the hook.
- * @param unsubscribeGraceTime (= 200): Amount of time in ms that the shared
- * observable should wait before unsubscribing from the source observable when
- * there are no new subscribers.
  *
  * @remarks If the Observable doesn't synchronously emit a value upon the first
  * subscription, then the hook will leverage React Suspense while it's waiting
  * for the first value.
  */
-export default function connectObservable<T>(
-  observable: Observable<T>,
-  unsubscribeGraceTime: number,
-) {
+export default function connectObservable<T>(observable: Observable<T>) {
   const sharedObservable$ = shareLatest<T>(observable)
-  const reactObservable$ = reactEnhancer(
-    sharedObservable$,
-    unsubscribeGraceTime,
-  )
+  const reactObservable$ = reactEnhancer(sharedObservable$)
   const outputObservable$ = takeUntilComplete(sharedObservable$)
   const useStaticObservable = () => useObservable(reactObservable$)
   return [useStaticObservable, outputObservable$] as const

--- a/packages/core/src/bind/index.ts
+++ b/packages/core/src/bind/index.ts
@@ -7,9 +7,6 @@ import connectObservable from "./connectObservable"
  * Binds an observable to React
  *
  * @param observable Source observable to be used by the hook.
- * @param unsubscribeGraceTime (= 200): Amount of time in ms that the shared
- * observable should wait before unsubscribing from the source observable when
- * there are no new subscribers.
  * @returns [1, 2]
  * 1. A React Hook that yields the latest emitted value of the observable
  * 2. A `sharedLatest` version of the observable. It can be used for composing
@@ -22,7 +19,6 @@ import connectObservable from "./connectObservable"
  */
 export function bind<T>(
   observable: Observable<T>,
-  unsubscribeGraceTime?: number,
 ): [() => Exclude<T, typeof SUSPENSE>, Observable<T>]
 
 /**
@@ -30,9 +26,6 @@ export function bind<T>(
  *
  * @param getObservable Factory of observables. The arguments of this function
  *  will be the ones used in the hook.
- * @param unsubscribeGraceTime (= 200): Amount of time in ms that the shared
- *  observable should wait before unsubscribing from the source observable when
- *  there are no new subscribers.
  * @returns [1, 2]
  * 1. A React Hook function with the same parameters as the factory function.
  *  This hook will yield the latest update from the observable returned from
@@ -48,14 +41,12 @@ export function bind<T>(
  */
 export function bind<A extends unknown[], O>(
   getObservable: (...args: A) => Observable<O>,
-  unsubscribeGraceTime?: number,
 ): [(...args: A) => Exclude<O, typeof SUSPENSE>, (...args: A) => Observable<O>]
 
 export function bind<A extends unknown[], O>(
   obs: ((...args: A) => Observable<O>) | Observable<O>,
-  unsubscribeGraceTime = 200,
 ) {
   return (typeof obs === "function"
     ? (connectFactoryObservable as any)
-    : connectObservable)(obs, unsubscribeGraceTime)
+    : connectObservable)(obs)
 }

--- a/packages/core/src/internal/noop.ts
+++ b/packages/core/src/internal/noop.ts
@@ -1,1 +1,0 @@
-export const noop = Function.prototype as () => void

--- a/packages/core/src/internal/react-enhancer.ts
+++ b/packages/core/src/internal/react-enhancer.ts
@@ -1,9 +1,8 @@
-import { Observable } from "rxjs"
+import { Observable, noop } from "rxjs"
 import { take, filter, tap } from "rxjs/operators"
 import { SUSPENSE } from "../SUSPENSE"
 import { BehaviorObservable } from "./BehaviorObservable"
 import { EMPTY_VALUE } from "./empty-value"
-import { noop } from "./noop"
 import { COMPLETE } from "./COMPLETE"
 
 const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {

--- a/packages/core/src/internal/react-enhancer.ts
+++ b/packages/core/src/internal/react-enhancer.ts
@@ -58,7 +58,7 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
       timeoutToken = setTimeout(() => {
         error = EMPTY_VALUE
       }, 50)
-      throw error
+      return error
     }
 
     try {
@@ -70,7 +70,6 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
       if (promise) return promise
 
       let value = EMPTY_VALUE
-      let isSyncError = false
       promise = {
         type: "s",
         payload: result
@@ -82,7 +81,7 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
                 value = v
               },
               error(e) {
-                error = e
+                error = { type: "e", payload: e }
                 timeoutToken = setTimeout(() => {
                   error = EMPTY_VALUE
                 }, 50)
@@ -90,10 +89,7 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
             }),
           )
           .toPromise()
-          .catch((e) => {
-            if (isSyncError) return
-            throw e
-          })
+          .catch(() => {})
           .finally(() => {
             promise = undefined
             valueResult = undefined
@@ -105,8 +101,7 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
       }
 
       if (error !== EMPTY_VALUE) {
-        isSyncError = true
-        throw error
+        return error
       }
 
       return promise

--- a/packages/core/src/internal/react-enhancer.ts
+++ b/packages/core/src/internal/react-enhancer.ts
@@ -50,7 +50,6 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
 
   let promise: any
   let error = EMPTY_VALUE
-  let valueResult: { type: "v"; payload: any } | undefined
   const getValue = () => {
     let timeoutToken
     if (error !== EMPTY_VALUE) {
@@ -62,10 +61,10 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
     }
 
     try {
-      const latest = (source$ as BehaviorObservable<T>).getValue()
-      return valueResult && Object.is(valueResult.payload, latest)
-        ? valueResult
-        : (valueResult = { type: "v", payload: latest })
+      return {
+        type: "v",
+        payload: (source$ as BehaviorObservable<T>).getValue(),
+      }
     } catch (e) {
       if (promise) return promise
 
@@ -92,12 +91,11 @@ const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
           .catch(() => {})
           .finally(() => {
             promise = undefined
-            valueResult = undefined
           }),
       }
 
       if (value !== EMPTY_VALUE) {
-        return (valueResult = { type: "v", payload: value })
+        return { type: "v", payload: value }
       }
 
       if (error !== EMPTY_VALUE) {

--- a/packages/core/src/internal/share-latest.ts
+++ b/packages/core/src/internal/share-latest.ts
@@ -1,8 +1,7 @@
-import { Observable, Subscription, Subject } from "rxjs"
+import { Observable, Subscription, Subject, noop } from "rxjs"
 import { SUSPENSE } from "../SUSPENSE"
 import { BehaviorObservable } from "./BehaviorObservable"
 import { EMPTY_VALUE } from "./empty-value"
-import { noop } from "./noop"
 import { COMPLETE } from "./COMPLETE"
 
 const shareLatest = <T>(

--- a/packages/core/src/internal/useObservable.ts
+++ b/packages/core/src/internal/useObservable.ts
@@ -1,10 +1,10 @@
 import { useEffect, useReducer } from "react"
 import { BehaviorObservable } from "./BehaviorObservable"
 import { SUSPENSE } from "../SUSPENSE"
+import { Observable } from "rxjs"
 
 const ERROR: "e" = "e"
 const VALUE: "v" = "v"
-const SUSP: "s" = "s"
 type Action = "e" | "v" | "s"
 
 const reducer = (
@@ -17,15 +17,31 @@ const reducer = (
 
 const init = (source$: BehaviorObservable<any>) => source$.getValue()
 
+const defaultSUSPENSE = <T>(source$: Observable<T>) =>
+  new Observable<T | typeof SUSPENSE>((observer) => {
+    let isEmpty = true
+    const subscription = source$.subscribe(
+      (x) => {
+        isEmpty = false
+        observer.next(x)
+      },
+      (e) => observer.error(e),
+    )
+
+    if (isEmpty) {
+      observer.next(SUSPENSE)
+    }
+
+    return subscription
+  })
+
 export const useObservable = <O>(
   source$: BehaviorObservable<O>,
 ): Exclude<O, typeof SUSPENSE> => {
   const [state, dispatch] = useReducer(reducer, source$, init)
-  if (state.type === ERROR) throw state.payload
 
   useEffect(() => {
-    dispatch(source$.getValue())
-    const subscription = source$.subscribe(
+    const subscription = defaultSUSPENSE(source$).subscribe(
       (value) => {
         if ((value as any) === SUSPENSE) {
           dispatch(source$.getValue())
@@ -45,8 +61,7 @@ export const useObservable = <O>(
     return () => subscription.unsubscribe()
   }, [source$])
 
-  if (state.type === SUSP) {
-    throw state.payload
-  }
-  return state.payload
+  const { type, payload } = state
+  if (type === VALUE) return payload
+  throw payload
 }

--- a/packages/core/src/internal/useObservable.ts
+++ b/packages/core/src/internal/useObservable.ts
@@ -10,15 +10,10 @@ type Action = "e" | "v" | "s"
 const reducer = (
   current: { type: Action; payload: any },
   action: { type: Action; payload: any },
-) => {
-  if (action.type === ERROR) {
-    throw action.payload
-  }
-  return Object.is(current.payload, action.payload) &&
-    current.type === action.type
+) =>
+  Object.is(current.payload, action.payload) && current.type === action.type
     ? current
     : action
-}
 
 const init = (source$: BehaviorObservable<any>) => source$.getValue()
 
@@ -26,13 +21,10 @@ export const useObservable = <O>(
   source$: BehaviorObservable<O>,
 ): Exclude<O, typeof SUSPENSE> => {
   const [state, dispatch] = useReducer(reducer, source$, init)
+  if (state.type === ERROR) throw state.payload
 
   useEffect(() => {
-    try {
-      dispatch(source$.getValue())
-    } catch (e) {
-      return dispatch({ type: ERROR, payload: e })
-    }
+    dispatch(source$.getValue())
     const subscription = source$.subscribe(
       (value) => {
         if ((value as any) === SUSPENSE) {

--- a/packages/core/src/useSubscribe.test.ts
+++ b/packages/core/src/useSubscribe.test.ts
@@ -3,10 +3,8 @@ import { share, finalize } from "rxjs/operators"
 import { renderHook } from "@testing-library/react-hooks"
 import { useSubscribe } from "./"
 
-const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
-
 describe("useSubscribe", () => {
-  it("subscribes to the provided observable and remains subscribed until it's unmounted", async () => {
+  it("subscribes to the provided observable and remains subscribed until it's unmounted", () => {
     let nSubscriptions = 0
     const source$ = defer(() => {
       nSubscriptions++
@@ -20,15 +18,11 @@ describe("useSubscribe", () => {
 
     expect(nSubscriptions).toBe(0)
 
-    const { unmount } = renderHook(() => useSubscribe(source$, 201))
+    const { unmount } = renderHook(() => useSubscribe(source$))
 
     expect(nSubscriptions).toBe(1)
 
     unmount()
-    expect(nSubscriptions).toBe(1)
-
-    await wait(250)
-
     expect(nSubscriptions).toBe(0)
   })
 })

--- a/packages/core/src/useSubscribe.ts
+++ b/packages/core/src/useSubscribe.ts
@@ -6,24 +6,13 @@ import { useEffect } from "react"
  * component mounts and it unsubscribes when the component unmounts.
  *
  * @param source$ Source observable that the hook will subscribe to.
- * @param unsubscribeGraceTime (= 200): Amount of time in ms that the hook
- * should wait before unsubscribing from the source observable after it unmounts.
  * @returns void
  *
  * @remarks This hook doesn't trigger any updates.
  */
-export const useSubscribe = <T>(
-  source$: Observable<T>,
-  unsubscribeGraceTime = 200,
-) => {
+export const useSubscribe = <T>(source$: Observable<T>) => {
   useEffect(() => {
     const subscription = source$.subscribe()
-    return () => {
-      /* istanbul ignore else */
-      if (unsubscribeGraceTime !== Infinity)
-        setTimeout(() => {
-          subscription.unsubscribe()
-        }, unsubscribeGraceTime)
-    }
-  }, [source$, unsubscribeGraceTime])
+    return () => subscription.unsubscribe()
+  }, [source$])
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -36,7 +36,7 @@
     "Victor Oliva (https://github.com/voliva)"
   ],
   "devDependencies": {
-    "@react-rxjs/core": "0.2.0",
+    "@react-rxjs/core": "0.3.0",
     "@testing-library/react": "^10.4.9",
     "@testing-library/react-hooks": "^3.4.1",
     "@types/jest": "^26.0.10",

--- a/packages/dom/src/batchUpdates.test.tsx
+++ b/packages/dom/src/batchUpdates.test.tsx
@@ -7,17 +7,15 @@ import { render, screen } from "@testing-library/react"
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
-const [useLatestNumber] = bind(
-  (id: string, batched: boolean) =>
-    (id === "error"
-      ? throwError("controlled error")
-      : from([1, 2, 3, 4, 5])
-    ).pipe(
-      delay(5),
-      batched ? batchUpdates() : (x: Observable<number>) => x,
-      startWith(0),
-    ),
-  0,
+const [useLatestNumber] = bind((id: string, batched: boolean) =>
+  (id === "error"
+    ? throwError("controlled error")
+    : from([1, 2, 3, 4, 5])
+  ).pipe(
+    delay(5),
+    batched ? batchUpdates() : (x: Observable<number>) => x,
+    startWith(0),
+  ),
 )
 
 class TestErrorBoundary extends Component<

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,7 @@
     "Victor Oliva (https://github.com/voliva)"
   ],
   "devDependencies": {
-    "@react-rxjs/core": "0.2.0",
+    "@react-rxjs/core": "0.3.0",
     "@testing-library/react": "^10.4.9",
     "@testing-library/react-hooks": "^3.4.1",
     "@types/jest": "^26.0.10",


### PR DESCRIPTION
After putting a lot of thought into this... These are the changes/improvements that I would like to suggest for version `0.3.0`:
- As we have already discussed offline, it's just better to get rid of the `unsubscribeGraceTime` parameter.
- I've made a few improvements on the logic that handles the async errors on Suspense
- The most important change: currently the factory observable cleans-up its cache once the observable has lost all its subscribers. That's very annoying. So, I thought about a lot of options: having a flag for persisting it, passing a duration observable, etc, etc... And then I realized that in fact there is a much simpler and logical approach: only remove it if it has completed by the time that the refcount goes down to zero. There are some new tests for that functionality. I really think that this is the way to go.