### PR TITLE
chore(typings): bring types in line with RxJs

### DIFF
--- a/packages/core/src/shareLatest.ts
+++ b/packages/core/src/shareLatest.ts
@@ -1,4 +1,4 @@
-import { Observable } from "rxjs"
+import { Observable, MonoTypeOperatorFunction } from "rxjs"
 import internalShareLatest from "./internal/share-latest"
 import { takeUntilComplete } from "./internal/take-until-complete"
 
@@ -16,5 +16,6 @@ import { takeUntilComplete } from "./internal/take-until-complete"
  * @remarks The enhanced observables returned from `connectObservable` and
  * `connectFactoryObservable` have been enhanced with this operator.
  */
-export const shareLatest = <T>() => (source$: Observable<T>) =>
-  takeUntilComplete(internalShareLatest(source$))
+export const shareLatest = <T>(): MonoTypeOperatorFunction<T> => (
+  source$: Observable<T>,
+) => takeUntilComplete(internalShareLatest(source$))

--- a/packages/utils/src/collect.ts
+++ b/packages/utils/src/collect.ts
@@ -1,4 +1,4 @@
-import { GroupedObservable, Observable } from "rxjs"
+import { GroupedObservable, Observable, OperatorFunction } from "rxjs"
 import {
   startWith,
   endWith,
@@ -22,7 +22,10 @@ const defaultFilter = (source$: Observable<any>) =>
  */
 export const collect = <K, V>(
   filter?: (source$: GroupedObservable<K, V>) => Observable<boolean>,
-) => {
+): OperatorFunction<
+  GroupedObservable<K, V>,
+  Map<K, GroupedObservable<K, V>>
+> => {
   const enhancer = filter
     ? (source$: GroupedObservable<K, V>) =>
         filter(source$).pipe(

--- a/packages/utils/src/collectValues.ts
+++ b/packages/utils/src/collectValues.ts
@@ -1,4 +1,4 @@
-import { Observable, GroupedObservable } from "rxjs"
+import { Observable, GroupedObservable, OperatorFunction } from "rxjs"
 import { map, endWith } from "rxjs/operators"
 import { set, del, collector } from "./internal-utils"
 
@@ -6,9 +6,10 @@ import { set, del, collector } from "./internal-utils"
  * A pipeable operator that collects all the GroupedObservables emitted by
  * the source and emits a Map with the latest values of the inner observables.
  */
-export const collectValues = <K, V>() => (
-  source$: Observable<GroupedObservable<K, V>>,
-): Observable<Map<K, V>> =>
+export const collectValues = <K, V>(): OperatorFunction<
+  GroupedObservable<K, V>,
+  Map<K, V>
+> => (source$: Observable<GroupedObservable<K, V>>): Observable<Map<K, V>> =>
   collector(source$, (inner$) =>
     inner$.pipe(
       map((v) => ({ t: set, k: inner$.key, v })),

--- a/packages/utils/src/split.ts
+++ b/packages/utils/src/split.ts
@@ -1,4 +1,10 @@
-import { Observable, GroupedObservable, Subject, ReplaySubject } from "rxjs"
+import {
+  Observable,
+  GroupedObservable,
+  Subject,
+  ReplaySubject,
+  OperatorFunction,
+} from "rxjs"
 import { shareReplay } from "rxjs/operators"
 
 const emptyError = {}
@@ -9,9 +15,9 @@ const emptyError = {}
  *
  * @param keySelector Function to define the group of an item
  */
-export function split<K, T>(
+export function split<T, K>(
   keySelector: (value: T) => K,
-): (stream: Observable<T>) => Observable<GroupedObservable<K, T>>
+): OperatorFunction<T, GroupedObservable<K, T>>
 
 /**
  * Groups the items emitted by the source based on the keySelector function,
@@ -20,15 +26,15 @@ export function split<K, T>(
  * @param keySelector Function to define the group of an item
  * @param streamSelector Function to apply to each resulting group
  */
-export function split<K, T, R>(
+export function split<T, K, R>(
   keySelector: (value: T) => K,
   streamSelector: (grouped: Observable<T>, key: K) => Observable<R>,
-): (stream: Observable<T>) => Observable<GroupedObservable<K, R>>
+): OperatorFunction<T, GroupedObservable<K, R>>
 
-export function split<K, T, R>(
+export function split<T, K, R>(
   keySelector: (value: T) => K,
   streamSelector?: (grouped: Observable<T>, key: K) => Observable<R>,
-) {
+): OperatorFunction<T, GroupedObservable<K, R>> {
   return (stream: Observable<T>) =>
     new Observable<GroupedObservable<K, R>>((subscriber) => {
       const groups: Map<K, Subject<T>> = new Map()

--- a/packages/utils/src/suspended.ts
+++ b/packages/utils/src/suspended.ts
@@ -1,6 +1,9 @@
 import { suspend } from "./suspend"
+import { OperatorFunction } from "rxjs"
+import { SUSPENSE } from "@react-rxjs/core"
 
 /**
  * A RxJS pipeable operator that prepends a SUSPENSE on the source observable.
  */
-export const suspended = () => suspend
+export const suspended = <T>(): OperatorFunction<T, T | typeof SUSPENSE> =>
+  suspend

--- a/packages/utils/src/switchMapSuspended.ts
+++ b/packages/utils/src/switchMapSuspended.ts
@@ -1,6 +1,12 @@
-import { ObservableInput, Observable } from "rxjs"
+import {
+  ObservableInput,
+  Observable,
+  OperatorFunction,
+  ObservedValueOf,
+} from "rxjs"
 import { switchMap } from "rxjs/operators"
 import { suspend } from "./suspend"
+import { SUSPENSE } from "@react-rxjs/core"
 
 /**
  * Same behaviour as rxjs' `switchMap`, but prepending every new event with
@@ -8,6 +14,8 @@ import { suspend } from "./suspend"
  *
  * @param fn Projection function
  */
-export const switchMapSuspended = <Input, Output>(
-  fn: (input: Input) => ObservableInput<Output>,
-) => (src$: Observable<Input>) => src$.pipe(switchMap((x) => suspend(fn(x))))
+export const switchMapSuspended = <T, O extends ObservableInput<any>>(
+  project: (value: T, index: number) => O,
+): OperatorFunction<T, ObservedValueOf<O> | typeof SUSPENSE> => (
+  src$: Observable<T>,
+) => src$.pipe(switchMap((x, index) => suspend(project(x, index))))


### PR DESCRIPTION
- use OperatorFunction and MonoTypeOperatorFunction where appropriate
- switch order of type arguments on "split" (from K,T,R to T,K,R) so that it matches other operators like groupBy
- change typings of switchMapSuspended so that it matches RxJs switchMap (now uses ObservedValueOf)

no code changes; all tests still pass