### PR TITLE
chore(docs): fix local readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ component mounts and it unsubscribes when the component unmounts.
 Arguments:
 
 - `source$`: Source observable that the hook will subscribe to.
-- `unsubscribeGraceTime`: Amount of time in ms that the hook should wait before
-  unsubscribing from the source observable after it unmounts (default = 200).
 
 Important: This hook doesn't trigger any updates.
 
@@ -152,9 +150,8 @@ the component mounts and it unsubscribes from it when the component unmounts.
 Properties:
 
 - `source$`: Source observable that the Component will subscribe to.
-- `graceTime`: an optional property that describes the amount of time in ms
-  that the Component should wait before unsubscribing from the source observable
-  after it unmounts (default = 200).
+- `fallback?`: The JSX Element to be rendered before the subscription is created.
+  It defaults to `null`.
 
 Important: This Component doesn't trigger any updates.
 


### PR DESCRIPTION
- remove references to graceTime from root readme, i.e. bring in line with packages readme