### PR TITLE
fix(core): factory bind multiple (un/re)subscriptions

### DIFF
--- a/packages/core/src/bind/connectFactoryObservable.ts
+++ b/packages/core/src/bind/connectFactoryObservable.ts
@@ -1,4 +1,4 @@
-import { Observable } from "rxjs"
+import { Observable, defer } from "rxjs"
 import shareLatest from "../internal/share-latest"
 import reactEnhancer from "../internal/react-enhancer"
 import { BehaviorObservable } from "../internal/BehaviorObservable"
@@ -55,8 +55,16 @@ export default function connectFactoryObservable<A extends [], O>(
 
     const reactObservable$ = reactEnhancer(sharedObservable$)
 
+    const publicShared$: Observable<O> = defer(() => {
+      const inCache = cache.get(keys)
+      if (inCache) {
+        return inCache[0] === publicShared$ ? sharedObservable$ : inCache[0]
+      }
+      return getSharedObservables$(input)[0]
+    })
+
     const result: [Observable<O>, BehaviorObservable<O>] = [
-      sharedObservable$,
+      publicShared$,
       reactObservable$,
     ]
 


### PR DESCRIPTION
As @voliva pointed out to me offline, the current behaviour of the shared-observable returned from the "factory bind" is problematic, because a consumer could want to resubscribe to it after all its initial subscriptions have finished. Currently this would trigger an error and that's not the intended behaviour.

This PR addresses the behaviour of what it should occur when a new subscription happens on a shared-observable that was previously disposed. There are 2 possible scenarios here:

1) When the new subscription happens there is no instance on the cache for that given key: in this case a new instance will be added and all subsequent subscriptions will consume that instance until it's no longer needed.

2) There is already a new instance on the cache: in this case the new subscription will be wired to that one, so that we continue sharing the latest one.

There is a new test that testes all these behaviours. The test should probably be improved and broken down into 2-3 different tests that better document this behaviour.

I think that we can do that in a later moment, right now my priority is to push a patch with this fix.