### PR TITLE
utils(createListener): add createListener util

### DIFF
--- a/packages/utils/src/createListener.spec.ts
+++ b/packages/utils/src/createListener.spec.ts
@@ -1,0 +1,27 @@
+import { createListener } from "./"
+
+describe("createListener", () => {
+  it('receives an "event creator" and it returns a tuple with an observable and its corresponding event-emitter', () => {
+    const [fooBar$, onFooBar] = createListener((foo: number, bar: string) => ({
+      foo,
+      bar,
+    }))
+    let receivedValue
+    fooBar$.subscribe((val) => {
+      receivedValue = val
+    })
+    expect(receivedValue).toBe(undefined)
+    onFooBar(0, "1")
+    expect(receivedValue).toEqual({ foo: 0, bar: "1" })
+  })
+  it('returns a tuple with a void observable and its corresponding event-emitter when no "event creator" is provided', () => {
+    const [clicks$, onClick] = createListener()
+    let count = 0
+    clicks$.subscribe(() => {
+      count++
+    })
+    expect(count).toBe(0)
+    onClick()
+    expect(count).toBe(1)
+  })
+})

--- a/packages/utils/src/createListener.ts
+++ b/packages/utils/src/createListener.ts
@@ -1,0 +1,15 @@
+import { Observable, Subject } from "rxjs"
+
+const defaultMapper: any = () => {}
+
+export function createListener<A extends unknown[], T>(
+  mapper: (...args: A) => T,
+): [Observable<T>, (...args: A) => void]
+export function createListener(): [Observable<void>, () => void]
+
+export function createListener<A extends unknown[], T>(
+  mapper: (...args: A) => T = defaultMapper,
+): [Observable<T>, (...args: A) => void] {
+  const subject = new Subject<T>()
+  return [subject.asObservable(), (...args: A) => subject.next(mapper(...args))]
+}

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -1,5 +1,6 @@
 export { collectValues } from "./collectValues"
 export { collect } from "./collect"
+export { createListener } from "./createListener"
 export { mergeWithKey } from "./mergeWithKey"
 export { split } from "./split"
 export { suspend } from "./suspend"


### PR DESCRIPTION
Closes #126 

After an "offline" conversation with @rikoe he convinced me that `createListener` -despite being a bit verbose- it's a better name than `newInput` or than `createInput`, and I think that he is right. So, here we go. Are we all happy with the name and with the signature?