### PR TITLE
feat(utils): startWith -> defaultStart on suspense utils

### DIFF
--- a/packages/utils/src/internal-utils.ts
+++ b/packages/utils/src/internal-utils.ts
@@ -9,8 +9,8 @@ import {
   mergeMap,
 } from "rxjs/operators"
 
-export const defaultStart = <T>(value: T) => (source$: Observable<T>) =>
-  new Observable<T>((observer) => {
+export const defaultStart = <T, D>(value: D) => (source$: Observable<T>) =>
+  new Observable<T | D>((observer) => {
     let emitted = false
     const subscription = source$.subscribe(
       (x) => {

--- a/packages/utils/src/suspend.test.ts
+++ b/packages/utils/src/suspend.test.ts
@@ -1,5 +1,6 @@
 import { TestScheduler } from "rxjs/testing"
 import { SUSPENSE } from "@react-rxjs/core"
+import { of } from "rxjs"
 import { suspend } from "./"
 
 const scheduler = () =>
@@ -12,6 +13,20 @@ describe("operators/suspend", () => {
     scheduler().run(({ expectObservable, cold }) => {
       const source = cold("----a")
       const expected = "   s---a"
+
+      const suspended = suspend(source)
+
+      expectObservable(suspended).toBe(expected, {
+        s: SUSPENSE,
+        a: "a",
+      })
+    })
+  })
+
+  it("does not prepend the source stream with SUSPENSE when the source is sync", () => {
+    scheduler().run(({ expectObservable }) => {
+      const source = of("a")
+      const expected = "(a|)"
 
       const suspended = suspend(source)
 

--- a/packages/utils/src/suspend.ts
+++ b/packages/utils/src/suspend.ts
@@ -1,6 +1,6 @@
 import { ObservableInput, from, Observable } from "rxjs"
-import { startWith } from "rxjs/operators"
 import { SUSPENSE } from "@react-rxjs/core"
+import { defaultStart } from "./internal-utils"
 
 /**
  * A RxJS creation operator that prepends a SUSPENSE on the source observable.
@@ -10,4 +10,4 @@ import { SUSPENSE } from "@react-rxjs/core"
 export const suspend: <T>(
   source$: ObservableInput<T>,
 ) => Observable<T | typeof SUSPENSE> = <T>(source$: ObservableInput<T>) =>
-  startWith(SUSPENSE)(from(source$)) as any
+  defaultStart(SUSPENSE)(from(source$)) as any

--- a/packages/utils/src/suspended.test.ts
+++ b/packages/utils/src/suspended.test.ts
@@ -1,5 +1,6 @@
 import { TestScheduler } from "rxjs/testing"
 import { SUSPENSE } from "@react-rxjs/core"
+import { of } from "rxjs"
 import { suspended } from "./"
 
 const scheduler = () =>
@@ -12,6 +13,20 @@ describe("operators/suspended", () => {
     scheduler().run(({ expectObservable, cold }) => {
       const source = cold("----a")
       const expected = "   s---a"
+
+      const result$ = source.pipe(suspended())
+
+      expectObservable(result$).toBe(expected, {
+        s: SUSPENSE,
+        a: "a",
+      })
+    })
+  })
+
+  it("does not prepend the source stream with SUSPENSE when the source is sync", () => {
+    scheduler().run(({ expectObservable }) => {
+      const source = of("a")
+      const expected = "(a|)"
 
       const result$ = source.pipe(suspended())
 

--- a/packages/utils/src/switchMapSuspended.test.ts
+++ b/packages/utils/src/switchMapSuspended.test.ts
@@ -1,6 +1,7 @@
 import { TestScheduler } from "rxjs/testing"
 import { SUSPENSE } from "@react-rxjs/core"
 import { switchMapSuspended } from "./"
+import { of } from "rxjs"
 
 const scheduler = () =>
   new TestScheduler((actual, expected) => {
@@ -28,6 +29,21 @@ describe("operators/switchMapSuspended", () => {
       const source = cold("-x--x")
       const inner = cold("     ----a")
       const expected = "   -s--s---a"
+
+      const result$ = source.pipe(switchMapSuspended(() => inner))
+
+      expectObservable(result$).toBe(expected, {
+        s: SUSPENSE,
+        a: "a",
+      })
+    })
+  })
+
+  it("does not emits another SUSPENSE when the next inner stream is sync", () => {
+    scheduler().run(({ expectObservable, cold }) => {
+      const source = cold("-x--x")
+      const inner = of("a")
+      const expected = "   -a--a"
 
       const result$ = source.pipe(switchMapSuspended(() => inner))
 


### PR DESCRIPTION
BREAKING CHANGE: suspend, suspended and switchMapSuspended will only emit SUSPENSE if the source doesn't emit synchronously