### PR TITLE
Removing graceTime and adding lots of perf improvements

### DIFF
--- a/packages/core/src/bind/connectFactoryObservable.ts
+++ b/packages/core/src/bind/connectFactoryObservable.ts
@@ -80,7 +80,7 @@ export default function connectFactoryObservable<A extends [], O>(
   return [
     (...input: A) => {
       const [source$, getValue] = getSharedObservables$(input)
-      return useObservable(source$, getValue)
+      return useObservable(source$, getValue, input)
     },
     (...input: A) => getSharedObservables$(input)[0],
   ]

--- a/packages/core/src/bind/connectObservable.ts
+++ b/packages/core/src/bind/connectObservable.ts
@@ -18,9 +18,11 @@ import { useObservable } from "../internal/useObservable"
  * subscription, then the hook will leverage React Suspense while it's waiting
  * for the first value.
  */
+const emptyArr: Array<any> = []
 export default function connectObservable<T>(observable: Observable<T>) {
   const sharedObservable$ = shareLatest<T>(observable, false)
   const getValue = reactEnhancer(sharedObservable$)
-  const useStaticObservable = () => useObservable(sharedObservable$, getValue)
+  const useStaticObservable = () =>
+    useObservable(sharedObservable$, getValue, emptyArr)
   return [useStaticObservable, sharedObservable$] as const
 }

--- a/packages/core/src/bind/connectObservable.ts
+++ b/packages/core/src/bind/connectObservable.ts
@@ -20,7 +20,7 @@ import { useObservable } from "../internal/useObservable"
  */
 export default function connectObservable<T>(observable: Observable<T>) {
   const sharedObservable$ = shareLatest<T>(observable, false)
-  const reactObservable$ = reactEnhancer(sharedObservable$)
-  const useStaticObservable = () => useObservable(reactObservable$)
+  const getValue = reactEnhancer(sharedObservable$)
+  const useStaticObservable = () => useObservable(sharedObservable$, getValue)
   return [useStaticObservable, sharedObservable$] as const
 }

--- a/packages/core/src/internal/BehaviorObservable.ts
+++ b/packages/core/src/internal/BehaviorObservable.ts
@@ -1,5 +1,6 @@
 import { Observable } from "rxjs"
+import { SUSPENSE } from "../SUSPENSE"
 
 export interface BehaviorObservable<T> extends Observable<T> {
-  getValue: () => any
+  getValue: () => T | typeof SUSPENSE
 }

--- a/packages/core/src/internal/BehaviorObservable.ts
+++ b/packages/core/src/internal/BehaviorObservable.ts
@@ -3,9 +3,3 @@ import { Observable } from "rxjs"
 export interface BehaviorObservable<T> extends Observable<T> {
   getValue: () => any
 }
-
-export const enum Action {
-  Error,
-  Value,
-  Suspense,
-}

--- a/packages/core/src/internal/react-enhancer.ts
+++ b/packages/core/src/internal/react-enhancer.ts
@@ -1,81 +1,59 @@
 import { Observable } from "rxjs"
 import { SUSPENSE } from "../SUSPENSE"
-import { BehaviorObservable, Action } from "./BehaviorObservable"
+import { BehaviorObservable } from "./BehaviorObservable"
 import { EMPTY_VALUE } from "./empty-value"
 
 const reactEnhancer = <T>(source$: Observable<T>): BehaviorObservable<T> => {
-  const result = new Observable<T>((subscriber) => {
-    let latestValue = EMPTY_VALUE
-    return source$.subscribe(
-      (value) => {
-        if (!Object.is(latestValue, value)) {
-          subscriber.next((latestValue = value))
-        }
-      },
-      (e) => {
-        subscriber.error(e)
-      },
-    )
-  }) as BehaviorObservable<T>
+  const result = new Observable<T>((subscriber) =>
+    source$.subscribe(subscriber),
+  ) as BehaviorObservable<T>
 
-  let promise: undefined | { type: Action.Suspense; payload: Promise<T | void> }
-  let error:
-    | typeof EMPTY_VALUE
-    | { type: Action.Error; payload: any } = EMPTY_VALUE
-  const getValue = (): { type: Action; payload: any } => {
+  let promise: Promise<T | void> | undefined
+  let error: any = EMPTY_VALUE
+  const getValue = (): T => {
     let timeoutToken
     if (error !== EMPTY_VALUE) {
       clearTimeout(timeoutToken)
       timeoutToken = setTimeout(() => {
         error = EMPTY_VALUE
       }, 50)
-      return error
+      throw error
     }
 
     try {
-      return {
-        type: Action.Value,
-        payload: (source$ as BehaviorObservable<T>).getValue(),
-      }
+      return (source$ as BehaviorObservable<T>).getValue()
     } catch (e) {
-      if (promise) return promise
+      if (promise) throw promise
 
-      let value:
-        | typeof EMPTY_VALUE
-        | { type: Action.Value; payload: T } = EMPTY_VALUE
+      let value: typeof EMPTY_VALUE | T = EMPTY_VALUE
 
-      promise = {
-        type: Action.Suspense,
-        payload: new Promise<T>((res) => {
-          const subscription = result.subscribe(
-            (v) => {
-              if (v !== (SUSPENSE as any)) {
-                value = { type: Action.Value, payload: v }
-                subscription && subscription.unsubscribe()
-                res(v)
-              }
-            },
-            (e) => {
-              error = { type: Action.Error, payload: e }
-              timeoutToken = setTimeout(() => {
-                error = EMPTY_VALUE
-              }, 50)
-              res()
-            },
-          )
-          if (value !== EMPTY_VALUE) {
-            subscription.unsubscribe()
-          }
-        }).finally(() => {
-          promise = undefined
-        }),
-      }
+      promise = new Promise<T>((res) => {
+        const subscription = result.subscribe(
+          (v) => {
+            if (v !== (SUSPENSE as any)) {
+              value = v
+              subscription && subscription.unsubscribe()
+              res(v)
+            }
+          },
+          (e) => {
+            error = e
+            timeoutToken = setTimeout(() => {
+              error = EMPTY_VALUE
+            }, 50)
+            res()
+          },
+        )
+        if (value !== EMPTY_VALUE) {
+          subscription.unsubscribe()
+        }
+      }).finally(() => {
+        promise = undefined
+      })
 
-      if (value !== EMPTY_VALUE) {
-        return value
-      }
+      if (value !== EMPTY_VALUE) return value
 
-      return error !== EMPTY_VALUE ? error : promise
+      throw error !== EMPTY_VALUE ? error : promise
     }
   }
   result.getValue = getValue

--- a/packages/core/src/internal/share-latest.ts
+++ b/packages/core/src/internal/share-latest.ts
@@ -1,5 +1,4 @@
 import { Observable, Subscription, Subject, noop } from "rxjs"
-import { SUSPENSE } from "../SUSPENSE"
 import { BehaviorObservable } from "./BehaviorObservable"
 import { EMPTY_VALUE } from "./empty-value"
 
@@ -58,12 +57,7 @@ const shareLatest = <T>(
     }
   }) as BehaviorObservable<T>
 
-  result.getValue = () => {
-    if (currentValue === EMPTY_VALUE || currentValue === (SUSPENSE as any)) {
-      throw currentValue
-    }
-    return currentValue
-  }
+  result.getValue = () => currentValue
 
   return result
 }

--- a/packages/core/src/internal/useObservable.ts
+++ b/packages/core/src/internal/useObservable.ts
@@ -6,6 +6,7 @@ import { Observable } from "rxjs"
 export const useObservable = <O>(
   source$: Observable<O>,
   getValue: () => O,
+  keys: Array<any>,
 ): Exclude<O, typeof SUSPENSE> => {
   const [state, setState] = useState(getValue)
   const prevStateRef = useRef<O | (() => O)>(state)
@@ -37,7 +38,7 @@ export const useObservable = <O>(
     t.unsubscribe()
 
     return () => subscription.unsubscribe()
-  }, [source$])
+  }, keys)
 
   return state as Exclude<O, typeof SUSPENSE>
 }

--- a/packages/core/src/internal/useObservable.ts
+++ b/packages/core/src/internal/useObservable.ts
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react"
-import { BehaviorObservable } from "./BehaviorObservable"
 import { SUSPENSE } from "../SUSPENSE"
 import { EMPTY_VALUE } from "./empty-value"
+import { Observable } from "rxjs"
 
 export const useObservable = <O>(
-  source$: BehaviorObservable<O>,
+  source$: Observable<O>,
+  getValue: () => O,
 ): Exclude<O, typeof SUSPENSE> => {
-  const [state, setState] = useState(source$.getValue)
+  const [state, setState] = useState(getValue)
 
   useEffect(() => {
     let prevVal: O | typeof SUSPENSE = EMPTY_VALUE
@@ -14,7 +15,7 @@ export const useObservable = <O>(
 
     const onNext = (value: O | typeof SUSPENSE) => {
       if (value === SUSPENSE) {
-        setState(source$.getValue)
+        setState(getValue)
       } else if (!Object.is(value, prevVal)) {
         setState(value)
       }
@@ -37,5 +38,5 @@ export const useObservable = <O>(
     return () => subscription.unsubscribe()
   }, [source$])
 
-  return state
+  return state as Exclude<O, typeof SUSPENSE>
 }

--- a/packages/dom/src/batchUpdates.test.tsx
+++ b/packages/dom/src/batchUpdates.test.tsx
@@ -1,6 +1,6 @@
 import React, { Component, ErrorInfo, useEffect } from "react"
 import { Observable, throwError, concat, Subject } from "rxjs"
-import { mergeMapTo, take, filter } from "rxjs/operators"
+import { mergeMapTo, take, filter, catchError } from "rxjs/operators"
 import { bind, Subscribe } from "@react-rxjs/core"
 import { batchUpdates } from "./"
 import { act, render, screen } from "@testing-library/react"
@@ -149,6 +149,9 @@ describe("batchUpdates", () => {
   test("batchUpdates doesn't get in the way of Error Boundaries", async () => {
     const mockFn = jest.fn()
     const errorCallback = jest.fn()
+    latestNumber$(true, true)
+      .pipe(catchError(() => []))
+      .subscribe()
     render(
       <TestErrorBoundary onError={errorCallback}>
         <Father batched error onRender={mockFn} />


### PR DESCRIPTION
The `graceTime` is a dangerous thing. No one should rely on it, it's an implementation detail. So, I've decided to remove it because it's not as useful as I initial thought it was. Also, it adds lots of unnecessary complexity.

There are 3 different commits in this PR:

1. Gets rid of the graceTimesecond
2. Simplifies *a lot* both: the `reactEnhancer` and `useObservable`
3. Removes `reactEnhancer` :tada: 