### PR TITLE
Impr/factory observable

### DIFF
--- a/packages/core/src/bind/connectFactoryObservable.test.tsx
+++ b/packages/core/src/bind/connectFactoryObservable.test.tsx
@@ -402,6 +402,30 @@ describe("connectFactoryObservable", () => {
 
       expect(errorCallback).not.toHaveBeenCalled()
     })
+
+    it("does not resubscribe to an observable that emits synchronously and that does not have a top-level subscription after a re-render", () => {
+      let nTopSubscriptions = 0
+
+      const [useNTopSubscriptions] = bind((id: number) =>
+        defer(() => {
+          return of(++nTopSubscriptions + id)
+        }),
+      )
+
+      const { result, rerender, unmount } = renderHook(() =>
+        useNTopSubscriptions(0),
+      )
+
+      expect(result.current).toBe(2)
+
+      actHook(() => {
+        rerender()
+      })
+      expect(result.current).toBe(2)
+      expect(nTopSubscriptions).toBe(2)
+
+      unmount()
+    })
   })
 
   describe("observable", () => {

--- a/packages/core/src/bind/connectFactoryObservable.ts
+++ b/packages/core/src/bind/connectFactoryObservable.ts
@@ -55,13 +55,14 @@ export default function connectFactoryObservable<A extends [], O>(
 
     const publicShared$ = new Observable<O>((subscriber) => {
       const inCache = cache.get(keys)
-      const source$ = inCache
-        ? inCache[0] === publicShared$
-          ? sharedObservable$
-          : inCache[0]
-        : getSharedObservables$(input)[0]
+      let source$: BehaviorObservable<O> = sharedObservable$
 
-      publicShared$.getValue = source$.getValue
+      if (!inCache) {
+        cache.set(keys, result)
+      } else if (inCache[0] !== publicShared$) {
+        source$ = inCache[0]
+        publicShared$.getValue = source$.getValue
+      }
 
       return source$.subscribe(subscriber)
     }) as BehaviorObservable<O>


### PR DESCRIPTION
The [last commit](https://github.com/re-rxjs/react-rxjs/pull/137/commits/5c14ec5c449ea90f5d9a19943bd0c67a7f33bbbc) on #137 was a fix without a test. This PR adds a test for that commit, plus another commit with a tiny perf improvement for factory-observables.