### PR TITLE
fix(bind): supports variadic number of arguments

### DIFF
--- a/packages/core/src/bind/connectFactoryObservable.test.tsx
+++ b/packages/core/src/bind/connectFactoryObservable.test.tsx
@@ -59,6 +59,22 @@ describe("connectFactoryObservable", () => {
       expect(result.current).toBe(3)
     })
 
+    it("accepts a changing number of arguments", async () => {
+      const [useConcatNumber] = bind((...args: number[]) => of(args.join(",")))
+      const { result, rerender } = renderHook(
+        ({ args }) => useConcatNumber(...args),
+        {
+          initialProps: {
+            args: [1],
+          },
+        },
+      )
+      expect(result.current).toBe("1")
+
+      rerender({ args: [1, 2] })
+      expect(result.current).toBe("1,2")
+    })
+
     it("suspends the component when the observable hasn't emitted yet.", async () => {
       const source$ = of(1).pipe(delay(100))
       const [useDelayedNumber, getDelayedNumber$] = bind(() => source$)

--- a/packages/core/src/bind/connectFactoryObservable.ts
+++ b/packages/core/src/bind/connectFactoryObservable.ts
@@ -83,7 +83,7 @@ export default function connectFactoryObservable<A extends [], O>(
   return [
     (...input: A) => {
       const [source$, getValue] = getSharedObservables$(input)
-      return useObservable(source$, getValue, input)
+      return useObservable(source$, getValue)
     },
     (...input: A) => getSharedObservables$(input)[0],
   ]

--- a/packages/core/src/bind/connectObservable.ts
+++ b/packages/core/src/bind/connectObservable.ts
@@ -19,14 +19,12 @@ import { EMPTY_VALUE } from "../internal/empty-value"
  * subscription, then the hook will leverage React Suspense while it's waiting
  * for the first value.
  */
-const emptyArr: Array<any> = []
 export default function connectObservable<T>(
   observable: Observable<T>,
   defaultValue: T = EMPTY_VALUE,
 ) {
   const sharedObservable$ = shareLatest<T>(observable, false)
   const getValue = reactEnhancer(sharedObservable$, defaultValue)
-  const useStaticObservable = () =>
-    useObservable(sharedObservable$, getValue, emptyArr)
+  const useStaticObservable = () => useObservable(sharedObservable$, getValue)
   return [useStaticObservable, sharedObservable$] as const
 }

--- a/packages/core/src/internal/useObservable.ts
+++ b/packages/core/src/internal/useObservable.ts
@@ -6,7 +6,6 @@ import { EMPTY_VALUE } from "./empty-value"
 export const useObservable = <O>(
   source$: Observable<O>,
   getValue: () => O,
-  keys: Array<any>,
 ): Exclude<O, typeof SUSPENSE> => {
   const [state, setState] = useState(getValue)
 
@@ -40,7 +39,7 @@ export const useObservable = <O>(
     return () => {
       subscription.unsubscribe()
     }
-  }, keys)
+  }, [source$])
 
   return state as Exclude<O, typeof SUSPENSE>
 }


### PR DESCRIPTION
Closes #156 

I'm not really sure we would officially support this feature, although it has been working on and off for a while. In our mental model, the parameters of a parametric `bind` are used to identify an instance of an entity.

As v0.5 is a version that helps the migration from 0.4 to 0.6 I think it's useful anyway to have this in.