### PR TITLE
fix(core): ensure that all subscriptions count for the refcount

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.5",
+  "version": "0.6.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/re-rxjs/react-rxjs.git"

--- a/packages/core/src/Subscribe.tsx
+++ b/packages/core/src/Subscribe.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Suspense, useLayoutEffect, ReactNode } from "react"
+import React, { useState, Suspense, useEffect, ReactNode } from "react"
 import { Observable, noop } from "rxjs"
 
 const p = Promise.resolve()
@@ -38,7 +38,7 @@ export const Subscribe: React.FC<{
     }
   }
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const subscription = source$.subscribe(noop, (e) =>
       setSubscribedSource(() => {
         throw e

--- a/packages/core/src/bind/connectFactoryObservable.ts
+++ b/packages/core/src/bind/connectFactoryObservable.ts
@@ -61,13 +61,11 @@ export default function connectFactoryObservable<A extends [], O>(
       } else if (inCache !== publicShared$) {
         source$ = inCache
         publicShared$.gV = source$.gV
-        publicShared$.aH = source$.aH
       }
 
       return source$.subscribe(subscriber)
     }) as BehaviorObservable<O>
     publicShared$.gV = sharedObservable$.gV
-    publicShared$.aH = sharedObservable$.aH
 
     const result: BehaviorObservable<O> = publicShared$
 

--- a/packages/core/src/internal/share-latest.ts
+++ b/packages/core/src/internal/share-latest.ts
@@ -74,19 +74,6 @@ const shareLatest = <T>(
     }
   }) as BehaviorObservable<T>
 
-  result.aH = (n: any, e: any) => {
-    let subscription
-    if (defaultValue === EMPTY_VALUE) {
-      subscription = subject!.subscribe(n, e)
-      if (currentValue !== EMPTY_VALUE) {
-        n(currentValue)
-      }
-    } else {
-      subscription = result.subscribe(n, e)
-    }
-    return subscription
-  }
-
   let error: any = EMPTY_VALUE
   let timeoutToken: any
   result.gV = (): T => {

--- a/packages/core/src/internal/useObservable.ts
+++ b/packages/core/src/internal/useObservable.ts
@@ -21,7 +21,7 @@ export const useObservable = <O>(
     }
 
     let isEmpty = true
-    const subscription = source$.aH(
+    const subscription = source$.subscribe(
       (value: O | typeof SUSPENSE) => {
         isEmpty = false
         if (value === SUSPENSE) {

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -40,7 +40,7 @@
     "Victor Oliva (https://github.com/voliva)"
   ],
   "devDependencies": {
-    "@react-rxjs/core": "0.6.5",
+    "@react-rxjs/core": "0.6.6",
     "@testing-library/react": "^11.2.3",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/jest": "^26.0.20",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,7 +40,7 @@
     "Victor Oliva (https://github.com/voliva)"
   ],
   "devDependencies": {
-    "@react-rxjs/core": "0.6.5",
+    "@react-rxjs/core": "0.6.6",
     "@testing-library/react": "^11.2.3",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/jest": "^26.0.20",


### PR DESCRIPTION
A little bit of context of what this bug is and how it got introduced, since we may need to revisit this in the future:

The issue got introduced by [this "fix"](https://github.com/re-rxjs/react-rxjs/commit/20e95697bb8faff51bcf55c1abe054d1f7ff4656). Let's first understand what that "fix" was about: If the `Subscribe` component gets remounted and the only consumers of its `source$` are its `children`, then the desired behavior is that when it remounts the `source$` shouldn't have any subscribers. However, that's not what was happening. There was a race-condition in which when the mount logic of the `Subscribe` component was being executed, the cleanup function for the `Subscribe` component had been evaluated, but the cleanup function of its children  hadn't been evaluated.

In order to "fix" this issue, my a "brilliant" idea was that since we have the guarantee that any time that a "bound hook" gets evaluated, the subscription to its underlying observable must exist already, then there is no need to take the subscription of the those hooks into account for the inner "refcount" of the underlying observable... :man_facepalming: I know, I know...

Anyways, it turns out that the race condition happened because `Subscribe` was using `useLayoutEffect` while the "bound hook" uses `useEffect`, so a better fix was to use `useEffect` on both and have all subscribers count in the "refcount" of the underlying observable.