### PR TITLE
feat(utils): `createKeyedSignal` improve mapper overload

### DIFF
--- a/packages/utils/src/contextBinder.ts
+++ b/packages/utils/src/contextBinder.ts
@@ -1,11 +1,6 @@
 import { Observable } from "rxjs"
 import { bind } from "@react-rxjs/core"
-
-type SubstractTuples<A1, A2> = A2 extends [unknown, ...infer Rest2]
-  ? A1 extends [unknown, ...infer Rest1]
-    ? SubstractTuples<Rest1, Rest2>
-    : []
-  : A1
+import type { SubstractTuples } from "./internal-utils"
 
 const execSelf = <T>(fn: () => T) => fn()
 

--- a/packages/utils/src/createKeyedSignal.spec.ts
+++ b/packages/utils/src/createKeyedSignal.spec.ts
@@ -3,8 +3,8 @@ import { createKeyedSignal } from "./"
 describe("createKeyedSignal", () => {
   it("receives a key selector and a mapper and returns a tuple with an observable-getter and its corresponding event-emitter", () => {
     const [getFooBar$, onFooBar] = createKeyedSignal(
-      (x) => x.key,
-      (foo: number, bar: string, key: string) => ({ foo, bar, key }),
+      (key: string) => key,
+      (_, foo: number, bar: string) => foo + bar,
     )
 
     let receivedValue1
@@ -15,7 +15,47 @@ describe("createKeyedSignal", () => {
     })
 
     expect(receivedValue1).toBe(undefined)
-    onFooBar(0, "1", "key")
+    onFooBar("key", 0, "1")
+    expect(receivedValue1).toBe("01")
+    expect(nHits1).toBe(1)
+
+    let receivedValue2
+    let nHits2 = 0
+    const subscription2 = getFooBar$("key").subscribe((val) => {
+      receivedValue2 = val
+      nHits2++
+    })
+
+    expect(receivedValue2).toBe(undefined)
+
+    onFooBar("key", 1, "2")
+    expect(receivedValue1).toBe("12")
+    expect(nHits1).toBe(2)
+    expect(receivedValue2).toBe("12")
+    expect(nHits2).toBe(1)
+
+    onFooBar("key2", 1, "2")
+    expect(nHits1).toBe(2)
+    expect(nHits2).toBe(1)
+
+    subscription1.unsubscribe()
+    subscription2.unsubscribe()
+  })
+
+  it("receives a key selector and returns a tuple with an observable-getter and its corresponding event-emitter", () => {
+    const [getFooBar$, onFooBar] = createKeyedSignal(
+      (signal: { key: string; foo: number; bar: string }) => signal.key,
+    )
+
+    let receivedValue1
+    let nHits1 = 0
+    const subscription1 = getFooBar$("key").subscribe((val) => {
+      receivedValue1 = val
+      nHits1++
+    })
+
+    expect(receivedValue1).toBe(undefined)
+    onFooBar({ key: "key", foo: 0, bar: "1" })
     expect(receivedValue1).toEqual({ foo: 0, bar: "1", key: "key" })
     expect(nHits1).toBe(1)
 
@@ -28,13 +68,13 @@ describe("createKeyedSignal", () => {
 
     expect(receivedValue2).toBe(undefined)
 
-    onFooBar(1, "2", "key")
+    onFooBar({ key: "key", foo: 1, bar: "2" })
     expect(receivedValue1).toEqual({ foo: 1, bar: "2", key: "key" })
     expect(nHits1).toBe(2)
     expect(receivedValue2).toEqual({ foo: 1, bar: "2", key: "key" })
     expect(nHits2).toBe(1)
 
-    onFooBar(1, "2", "key2")
+    onFooBar({ key: "key2", foo: 1, bar: "2" })
     expect(nHits1).toBe(2)
     expect(nHits2).toBe(1)
 

--- a/packages/utils/src/internal-utils.ts
+++ b/packages/utils/src/internal-utils.ts
@@ -67,3 +67,9 @@ export const collector = <K, V, VV>(
     if (!emitted) observer.next(map)
     return subscription
   }).pipe(shareLatest())
+
+export type SubstractTuples<A1, A2> = A2 extends [unknown, ...infer Rest2]
+  ? A1 extends [unknown, ...infer Rest1]
+    ? SubstractTuples<Rest1, Rest2>
+    : []
+  : A1


### PR DESCRIPTION
I think that `createKeyedSignal` is by far one of the best additions that we've made to the `utils` package. However, the "mapper" overload is not very ergonomic, for 2 reasons:

- When writing the key selector, TS hasn't been able to infer the type returned by the mapper yet
- In many cases what's desirable is to create an Observable of a mapped value that doesn't have the key

That's why I think that overload should be improved. Unfortunately, that implies a breaking change :confused:, luckily, though, we are still under major version zero :see_no_evil: 