### PR TITLE
feat(core): factory `bind` accept function for default value

### DIFF
--- a/packages/core/src/bind/connectFactoryObservable.test.tsx
+++ b/packages/core/src/bind/connectFactoryObservable.test.tsx
@@ -541,6 +541,33 @@ describe("connectFactoryObservable", () => {
       unmount()
     })
 
+    it("the defaultValue can be a function that receives the keys", () => {
+      const subj$ = new Subject<number>()
+      const [useNumber, number$] = bind(
+        (_: number) => subj$,
+        (key) => key,
+      )
+
+      const { result, unmount } = renderHook(() => useNumber(10))
+
+      expect(result.current).toBe(10)
+      let res = 0
+      number$(10)
+        .subscribe((x) => {
+          res = x
+        })
+        .unsubscribe()
+      expect(res).toBe(10)
+
+      actHook(() => {
+        subj$.next(5)
+      })
+
+      expect(result.current).toBe(5)
+
+      unmount()
+    })
+
     it("if the observable hasn't emitted and a defaultValue is provided, it does not start suspense", () => {
       const number$ = new Subject<number>()
       const [useNumber] = bind(

--- a/packages/core/src/bind/index.ts
+++ b/packages/core/src/bind/index.ts
@@ -43,7 +43,7 @@ export function bind<T>(
  */
 export function bind<A extends unknown[], O>(
   getObservable: (...args: A) => Observable<O>,
-  defaultValue?: O,
+  defaultValue?: O | ((...args: A) => O),
 ): [(...args: A) => Exclude<O, typeof SUSPENSE>, (...args: A) => Observable<O>]
 
 export function bind(observable: any, defaultValue: any) {


### PR DESCRIPTION
I've been meaning to make this improvement for a while now, but I never got to it... Technically speaking, this is a breaking change. Because in the super-rare event that someone was using a factory `bind` with Observables of functions and that the default-value overload was being used, then they will have to wrap that default function into another function... So, yeah, this should go into `0.7.0` I guess :shrug: 

@voliva  what do you think?