### PR TITLE
feat(utils/combineKeys): emit set with changed keys

### DIFF
--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -1,6 +1,6 @@
 export { collectValues } from "./collectValues"
 export { collect } from "./collect"
-export { combineKeys } from "./combineKeys"
+export { combineKeys, MapWithChanges } from "./combineKeys"
 export { getGroupedObservable } from "./getGroupedObservable"
 export { createSignal } from "./createSignal"
 export { createKeyedSignal } from "./createKeyedSignal"


### PR DESCRIPTION
Recently I found a use case where I'd like to have an operator similar to `combineKeys`, but that instead of emitting a map of values it would just emit the latest individual change.

I couldn't find any way of composing the existing operators to do this, so I had to make a custom operator which had mostly combineKeys' code changing a few lines.

After discussing it we found out that this operator would be easy to implement if the existing `combineKeys` also emitted the list of keys that have changed. This is a posible implementation.

With this operator, the mergeKeys operator I had in mind would become something like:

```ts
const mergeKeys = <K, T>(keys$: Observable<K>, getInner$: (key: K) => Observable<T>): Observable<T> =>
  combineKeys(keys$, getInner$).pipe(
    mergeMap(values => {
      return Array.from(values.changes)
        .map(key => values.get(key))
        .filter(value => value !== undefined)
    })
  )
```

Doubts on this one:
- Is it good to just add a property into the `Map`?
- I went for the same pattern to make a copy of the Set... I think an alternative would be to just return the existing Set and instantiate a new one for the next emission