### PR TITLE
Fix compile error on Next.js 12 (Directory import)

### DIFF
--- a/packages/core/src/internal/useObservable.ts
+++ b/packages/core/src/internal/useObservable.ts
@@ -1,5 +1,5 @@
 import { Subscription } from "rxjs"
-import { useSyncExternalStore } from "use-sync-external-store/shim"
+import { useSyncExternalStore } from "use-sync-external-store/shim/index.js"
 import { useRef, useState } from "react"
 import { SUSPENSE, filterOutSuspense } from "../SUSPENSE"
 import { DefaultedStateObservable, StateObservable } from "@josepot/rxjs-state"


### PR DESCRIPTION
We're using `react-rxjs` but have transitioned away to an SSR framework, however Node doesn't seem to support this syntax of importing from a directory without specifically writing `index.js`. 

Installing `react-rxjs` on a freshly setup Next.js project yields the following error when trying to import `bind` from `@react-rxjs/core`:
```
Error: Directory import '*<project>*/node_modules/use-sync-external-store/shim' is not supported resolving ES modules imported from *<project>*/node_modules/@react-rxjs/core/dist/core.es2019.mjs

Did you mean to import use-sync-external-store/shim/index.js?
```