### PR TITLE
Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8637,7 +8637,7 @@
     },
     "packages/core": {
       "name": "@react-rxjs/core",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@rxstate/core": "^0.0.1",
@@ -8656,7 +8656,7 @@
       "version": "0.1.8",
       "license": "MIT",
       "devDependencies": {
-        "@react-rxjs/core": "0.9.4"
+        "@react-rxjs/core": "0.9.5"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -8669,7 +8669,7 @@
       "version": "0.9.5",
       "license": "MIT",
       "devDependencies": {
-        "@react-rxjs/core": "0.9.4"
+        "@react-rxjs/core": "0.9.5"
       },
       "peerDependencies": {
         "@react-rxjs/core": ">=0.1.0",
@@ -10342,13 +10342,13 @@
     "@react-rxjs/dom": {
       "version": "file:packages/dom",
       "requires": {
-        "@react-rxjs/core": "0.9.4"
+        "@react-rxjs/core": "0.9.5"
       }
     },
     "@react-rxjs/utils": {
       "version": "file:packages/utils",
       "requires": {
-        "@react-rxjs/core": "0.9.4"
+        "@react-rxjs/core": "0.9.5"
       }
     },
     "@rxstate/core": {

--- a/packages/core/src/SUSPENSE.ts
+++ b/packages/core/src/SUSPENSE.ts
@@ -4,7 +4,4 @@
  * leverage React Suspense API while we are waiting for that value.
  */
 export const SUSPENSE = Symbol("SUSPENSE")
-
-export const filterOutSuspense = <T>(
-  value: T,
-): value is Exclude<T, typeof SUSPENSE> => value !== (SUSPENSE as any)
+export type SUSPENSE = typeof SUSPENSE

--- a/packages/core/src/useStateObservable.ts
+++ b/packages/core/src/useStateObservable.ts
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react"
-import { SUSPENSE, filterOutSuspense } from "./SUSPENSE"
+import { SUSPENSE } from "./SUSPENSE"
 import { DefaultedStateObservable, StateObservable } from "@rxstate/core"
 import { EMPTY_VALUE } from "./internal/empty-value"
 import useSyncExternalStore from "./internal/useSyncExternalStore"
@@ -11,6 +11,9 @@ interface Ref<T> {
   source$: StateObservable<T>
   args: [(cb: VoidCb) => VoidCb, () => Exclude<T, typeof SUSPENSE>]
 }
+
+const filterOutSuspense = <T>(value: T): value is Exclude<T, SUSPENSE> =>
+  value !== (SUSPENSE as any)
 
 export const useStateObservable = <O>(
   source$: StateObservable<O>,


### PR DESCRIPTION
A couple of small fixes:
- the versions of the package-lock.json
- make `SUSPENSE` also a type so that we don't always have to do `typeof SUSPENSE`, which I find super-annoying
- move `filterOutSuspense` inside `stateObservable` since it's only being used in there. The main motivation for this is that I have a similar function on my project and currently my editor sometimes suggests me to import the "internal" one b/c it appears on the `d.ts`.