### PR TITLE
fix: Subscribe with async errors

### DIFF
--- a/packages/core/src/Subscribe.test.tsx
+++ b/packages/core/src/Subscribe.test.tsx
@@ -1,10 +1,12 @@
 import { state } from "@rxstate/core"
-import { render, screen } from "@testing-library/react"
+import { render, screen, act } from "@testing-library/react"
 import React, { StrictMode, useState, useEffect } from "react"
 import { defer, EMPTY, NEVER, Observable, of, startWith } from "rxjs"
 import { bind, RemoveSubscribe, Subscribe as OriginalSubscribe } from "./"
 import { TestErrorBoundary } from "./test-helpers/TestErrorBoundary"
 import { useStateObservable } from "./useStateObservable"
+
+const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
 const Subscribe = (props: any) => {
   return (
@@ -302,6 +304,38 @@ describe("Subscribe", () => {
       )
 
       expect(hasError).toBe(false)
+    })
+
+    it("allows async errors to be caught in error boundaries with suspense, without using source$", async () => {
+      const [useError] = bind(
+        new Observable((obs) => {
+          setTimeout(() => obs.error("controlled error"), 10)
+        }),
+      )
+
+      const ErrorComponent = () => {
+        const value = useError()
+        return <>{value}</>
+      }
+
+      const errorCallback = jest.fn()
+      const { unmount } = render(
+        <TestErrorBoundary onError={errorCallback}>
+          <Subscribe fallback={<div>Loading...</div>}>
+            <ErrorComponent />
+          </Subscribe>
+        </TestErrorBoundary>,
+      )
+
+      await act(async () => {
+        await wait(100)
+      })
+
+      expect(errorCallback).toHaveBeenCalledWith(
+        "controlled error",
+        expect.any(Object),
+      )
+      unmount()
     })
   })
 })

--- a/packages/core/src/useStateObservable.ts
+++ b/packages/core/src/useStateObservable.ts
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react"
 import { SUSPENSE } from "./SUSPENSE"
 import { DefaultedStateObservable, StateObservable } from "@rxstate/core"
-import { EMPTY_VALUE } from "./internal/empty-value"
 import useSyncExternalStore from "./internal/useSyncExternalStore"
 import { useSubscription } from "./Subscribe"
 
@@ -31,20 +30,10 @@ export const useStateObservable = <O>(
 
     const gv: <T>() => Exclude<T, typeof SUSPENSE> = () => {
       const src = callbackRef.current!.source$ as DefaultedStateObservable<O>
-
-      if (src.getRefCount() > 0 || src.getDefaultValue) return getValue(src)
-
-      if (!subscription) throw new Error("Missing Subscribe!")
-
-      let error = EMPTY_VALUE
-      subscription.add(
-        src.subscribe({
-          error: (e) => {
-            error = e
-          },
-        }),
-      )
-      if (error !== EMPTY_VALUE) throw error
+      if (!src.getRefCount() && !src.getDefaultValue) {
+        if (!subscription) throw new Error("Missing Subscribe!")
+        subscription(src)
+      }
       return getValue(src)
     }
 


### PR DESCRIPTION
This PR adds a new test, which is currently failing on the `main` branch, and its corresponding fix.