### PR TITLE
fix Subscribe throwing NoSubscribersError on synchronous completes

### DIFF
--- a/packages/core/src/Subscribe.test.tsx
+++ b/packages/core/src/Subscribe.test.tsx
@@ -1,4 +1,9 @@
-import { sinkSuspense, state, SUSPENSE } from "@rx-state/core"
+import {
+  EmptyObservableError,
+  sinkSuspense,
+  state,
+  SUSPENSE,
+} from "@rx-state/core"
 import { act, render, screen } from "@testing-library/react"
 import React, { StrictMode, useEffect, useState } from "react"
 import { defer, EMPTY, NEVER, Observable, of, startWith, Subject } from "rxjs"
@@ -352,6 +357,31 @@ describe("Subscribe", () => {
         "controlled error",
         expect.any(Object),
       )
+      unmount()
+    })
+
+    it("propagates the EmptyObservable error if a stream completes synchronously", async () => {
+      const [useEmpty] = bind(() => EMPTY)
+
+      const ErrorComponent = () => {
+        useEmpty()
+        return null
+      }
+
+      const errorCallback = jest.fn()
+      const { unmount } = render(
+        <TestErrorBoundary onError={errorCallback}>
+          <Subscribe fallback={<div>Loading...</div>}>
+            <ErrorComponent />
+          </Subscribe>
+        </TestErrorBoundary>,
+      )
+
+      expect(errorCallback.mock.calls.length).toBe(1)
+      expect(errorCallback.mock.calls[0][0]).toBeInstanceOf(
+        EmptyObservableError,
+      )
+
       unmount()
     })
 

--- a/packages/core/src/Subscribe.test.tsx
+++ b/packages/core/src/Subscribe.test.tsx
@@ -384,7 +384,6 @@ describe("Subscribe", () => {
       // Can't have NoSubscribersError
       // Can't have "Cannot update component (`%s`) while rendering a different component"
       globalErrors.mock.calls.forEach(([errorMessage]) => {
-        console.log(errorMessage)
         expect(errorMessage).not.toContain(NoSubscribersError.name)
         expect(errorMessage).not.toContain(
           "Cannot update a component (`%s`) while rendering a different component",

--- a/packages/core/src/Subscribe.tsx
+++ b/packages/core/src/Subscribe.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react"
 import { Observable, Subscription } from "rxjs"
 import { liftSuspense, StateObservable } from "@rx-state/core"
+import { EMPTY_VALUE } from "./internal/empty-value"
 
 const SubscriptionContext = createContext<
   ((src: StateObservable<any>) => void) | null
@@ -54,14 +55,20 @@ export const Subscribe: React.FC<{
     subscriptionRef.current = {
       s,
       u: (src) => {
+        let error = EMPTY_VALUE
         s.add(
           liftSuspense()(src).subscribe({
-            error: (e) =>
+            error: (e) => {
+              error = e
               setSubscribedSource(() => {
                 throw e
-              }),
+              })
+            },
           }),
         )
+        if (error !== EMPTY_VALUE) {
+          throw error
+        }
       },
     }
   }

--- a/packages/core/src/Subscribe.tsx
+++ b/packages/core/src/Subscribe.tsx
@@ -56,16 +56,22 @@ export const Subscribe: React.FC<{
       s,
       u: (src) => {
         let error = EMPTY_VALUE
+        let synchronous = true
         s.add(
           liftSuspense()(src).subscribe({
             error: (e) => {
-              error = e
+              if (synchronous) {
+                // Can't setState of this component when another one is rendering.
+                error = e
+                return
+              }
               setSubscribedSource(() => {
                 throw e
               })
             },
           }),
         )
+        synchronous = false
         if (error !== EMPTY_VALUE) {
           throw error
         }


### PR DESCRIPTION
Unfortunately the test doesn't reproduce it :(

Maybe it's related to the testing framework? A simple sandbox does reproduce it: https://codesandbox.io/s/react-rxjs-playground-sfty1h?file=/src/App.tsx

I'll take a closer look this evening