### PR TITLE
fix: types not read when moduleResolution is not "node"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2360,9 +2360,9 @@
       "link": true
     },
     "node_modules/@rx-state/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@rx-state/core/-/core-0.1.2.tgz",
-      "integrity": "sha512-DU+ivXavjHB1O7MHCUkkPBb+ZGLVm+E1FqBnmyBF+FRMHdFsDUdx9DSQca9fXDggPsvk2otmJslthKDPsMz5nQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@rx-state/core/-/core-0.1.3.tgz",
+      "integrity": "sha512-dutjI6FLxIT18xw0eJhAMXf4pg0HRe+crZ3xtTd13pVCeteU8G+w69cjvQsGZsA04h/xxW4r9TCQ4DVsAbi1/w==",
       "peerDependencies": {
         "rxjs": ">=7"
       }
@@ -8640,7 +8640,7 @@
       "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
-        "@rx-state/core": "0.1.2",
+        "@rx-state/core": "0.1.3",
         "use-sync-external-store": "^1.0.0"
       },
       "devDependencies": {
@@ -10334,7 +10334,7 @@
     "@react-rxjs/core": {
       "version": "file:packages/core",
       "requires": {
-        "@rx-state/core": "0.1.2",
+        "@rx-state/core": "0.1.3",
         "@types/use-sync-external-store": "^0.0.3",
         "use-sync-external-store": "^1.0.0"
       }
@@ -10352,9 +10352,9 @@
       }
     },
     "@rx-state/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@rx-state/core/-/core-0.1.2.tgz",
-      "integrity": "sha512-DU+ivXavjHB1O7MHCUkkPBb+ZGLVm+E1FqBnmyBF+FRMHdFsDUdx9DSQca9fXDggPsvk2otmJslthKDPsMz5nQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@rx-state/core/-/core-0.1.3.tgz",
+      "integrity": "sha512-dutjI6FLxIT18xw0eJhAMXf4pg0HRe+crZ3xtTd13pVCeteU8G+w69cjvQsGZsA04h/xxW4r9TCQ4DVsAbi1/w==",
       "requires": {}
     },
     "@sinonjs/commons": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,13 +13,14 @@
         "import": "./dist/core.es2019.mjs",
         "require": "./dist/index.cjs"
       },
-      "default": "./dist/core.es2017.js"
+      "default": "./dist/core.es2017.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },
   "module": "./dist/core.es2017.js",
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -50,7 +51,7 @@
     "Victor Oliva (https://github.com/voliva)"
   ],
   "dependencies": {
-    "@rx-state/core": "0.1.2",
+    "@rx-state/core": "0.1.3",
     "use-sync-external-store": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -13,13 +13,14 @@
         "import": "./dist/dom.es2019.mjs",
         "require": "./dist/index.cjs"
       },
-      "default": "./dist/dom.es2017.js"
+      "default": "./dist/dom.es2017.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },
   "module": "./dist/dom.es2017.js",
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,13 +13,14 @@
         "import": "./dist/utils.es2019.mjs",
         "require": "./dist/index.cjs"
       },
-      "default": "./dist/utils.es2017.js"
+      "default": "./dist/utils.es2017.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },
   "module": "./dist/utils.es2017.js",
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes #298

I've brought it to @rx-state/core as well, released for 0.1.3

Sorry it took long to fix this @bmcbarron, I've tried it in local and it looks like this should work, right?