### PR TITLE
Add getServerSnapshot, fix loop on SSR Subscribe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/preset-env": "^7.22.7",
         "@babel/preset-typescript": "^7.22.5",
         "@testing-library/react": "^14.0.0",
+        "@types/node": "^20.4.7",
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "@vitest/coverage-v8": "^0.33.0",
@@ -2545,9 +2546,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "version": "20.4.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.7.tgz",
+      "integrity": "sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -8538,9 +8539,9 @@
       }
     },
     "@types/node": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
-      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "version": "20.4.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.7.tgz",
+      "integrity": "sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==",
       "dev": true
     },
     "@types/prop-types": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@babel/preset-env": "^7.22.7",
     "@babel/preset-typescript": "^7.22.5",
     "@testing-library/react": "^14.0.0",
+    "@types/node": "^20.4.7",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "@vitest/coverage-v8": "^0.33.0",

--- a/packages/core/src/Subscribe.tsx
+++ b/packages/core/src/Subscribe.tsx
@@ -125,6 +125,8 @@ export const Subscribe: React.FC<{
 
   return fallback === undefined ? (
     actualChildren
+  ) : subscribedSource === null ? (
+    fallback
   ) : (
     <Suspense fallback={fallback}>{actualChildren}</Suspense>
   )

--- a/packages/core/src/test-helpers/pipeableStreamToObservable.ts
+++ b/packages/core/src/test-helpers/pipeableStreamToObservable.ts
@@ -1,0 +1,41 @@
+import { PipeableStream } from "react-dom/server"
+import { Observable, scan } from "rxjs"
+import { PassThrough } from "stream"
+
+export function pipeableStreamToObservable(
+  stream: PipeableStream,
+): Observable<string> {
+  return new Observable((subscriber) => {
+    const passthrough = new PassThrough()
+    const sub = readStream$<string>(passthrough)
+      .pipe(scan((acc, v) => acc + v, ""))
+      .subscribe(subscriber)
+
+    stream.pipe(passthrough)
+
+    return () => {
+      sub.unsubscribe()
+    }
+  })
+}
+
+function readStream$<T>(stream: NodeJS.ReadableStream) {
+  return new Observable<T>((subscriber) => {
+    const dataHandler = (data: T) => subscriber.next(data)
+    stream.addListener("data", dataHandler)
+
+    const errorHandler = (error: any) => subscriber.error(error)
+    stream.addListener("error", errorHandler)
+
+    const closeHandler = () => subscriber.complete()
+    stream.addListener("close", closeHandler)
+    stream.addListener("end", closeHandler)
+
+    return () => {
+      stream.removeListener("data", dataHandler)
+      stream.removeListener("error", errorHandler)
+      stream.removeListener("close", closeHandler)
+      stream.removeListener("end", closeHandler)
+    }
+  })
+}

--- a/packages/core/src/useStateObservable.ts
+++ b/packages/core/src/useStateObservable.ts
@@ -14,7 +14,11 @@ type VoidCb = () => void
 
 interface Ref<T> {
   source$: StateObservable<T>
-  args: [(cb: VoidCb) => VoidCb, () => Exclude<T, SUSPENSE>]
+  args: [
+    (cb: VoidCb) => VoidCb,
+    () => Exclude<T, typeof SUSPENSE>,
+    () => Exclude<T, typeof SUSPENSE>,
+  ]
 }
 
 export const useStateObservable = <O>(
@@ -46,7 +50,7 @@ export const useStateObservable = <O>(
 
     callbackRef.current = {
       source$: null as any,
-      args: [, gv] as any,
+      args: [, gv, gv] as any,
     }
   }
 


### PR DESCRIPTION
Fixes #305 

Something important to keep in mind is that in SSR any children within a `Subscribe` will not render, because given that components never mount in SSR (including `<Subscribe>`), it will never get into the stage of rendering the children.

And `StateObservable` with top-level subscriptions will have their state shared between clients.