### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/packages/core/src/bind/connectFactoryObservable.test.tsx
+++ b/packages/core/src/bind/connectFactoryObservable.test.tsx
@@ -445,7 +445,7 @@ describe("connectFactoryObservable", () => {
 
         await componentAct(async () => {
           normal$.next("ALL GOOD")
-          await wait(50)
+          await wait(5)
         })
 
         expect(screen.queryByText("ALL GOOD")).not.toBeNull()


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 50ms to 10ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.